### PR TITLE
Build script updates

### DIFF
--- a/releases/build_rom.ini
+++ b/releases/build_rom.ini
@@ -1,10 +1,12 @@
-zip=1943u.zip
 # 1943
+#zip=1943.zip
 # ifiles=(bme01.12d bme02.13d bme03.14d bm05.4k bm04.5h bm14.5f bm23.8k bm15.10f bm19.10j bm16.11f bm20.11j bm17.12f bm21.12j bm18.14f bm22.14j bm24.14k bm25.14l bm06.10a bm10.10c bm07.11a bm11.11c bm08.12a bm12.12c bm09.14a bm13.14c bm10.7l bm11.12l bm1.12a bm12.12m bm2.13a bm3.14a bm4.12c bm5.7f bm6.4b bm7.7c bm8.8c bm9.6l)
+#ofileMd5sumValid=5006722f516b6fd1709046a542d3dd71
 
 # 1943u
+zip=1943u.zip
 ifiles=(bmu01c.12d bmu02c.13d bmu03c.14d bm05.4k bm04.5h bm14.5f bm23.8k bm15.10f bm19.10j bm16.11f bm20.11j bm17.12f bm21.12j bm18.14f bm22.14j bm24.14k bm25.14l bm06.10a bm10.10c bm07.11a bm11.11c bm08.12a bm12.12c bm09.14a bm13.14c bm10.7l bm11.12l bm1.12a bm12.12m bm2.13a bm3.14a bm4.12c bm5.7f bm6.4b bm7.7c bm8.8c bm9.6l)
+ofileMd5sumValid=9b5cfef91f91462265c977a365a453a6
 
 ofile=a.JT1943.rom
 ofile_mist=JT1943.rom
-ofileMd5sumValid=b034856e2abf228761a3828c8c883b4c

--- a/releases/build_rom.sh
+++ b/releases/build_rom.sh
@@ -69,7 +69,7 @@ validate_rom() {
     echo -e "Actual checksum:\n${ofileMd5sumCurrent}"
     mv ${BASEDIR}/${tmpdir}/${ofile} .
     rm -rf ${BASEDIR}/$tmpdir
-    echo -e "Generated ${ofile}\nis invalid.\nThis is more likely\ndue to incorrect\n${zip} content."
+    exit_with_error "Generated ${ofile}\nis invalid.\nThis is more likely\ndue to incorrect\n${zip} content."
   else
     mv ${BASEDIR}/${tmpdir}/${ofile} ${BASEDIR}/.
     rm -rf ${BASEDIR}/$tmpdir


### PR DESCRIPTION
- Use 1943s md5 checksum instead of 1942s.
- Fail with error code upon md5 mismatch.
- Rename script for consistency.